### PR TITLE
Add Tests (#38)

### DIFF
--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/_children/property-invitations/controllers/property-invitations.controller.spec.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/_children/property-invitations/controllers/property-invitations.controller.spec.ts
@@ -1,16 +1,78 @@
 import {TestBed} from '@automock/jest';
+import {faker} from '@faker-js/faker';
+import {AuthUser} from '@supabase/supabase-js';
 
 import {PropertyInvitationsController} from './property-invitations.controller';
+import {PropertyInvitationsService} from '../services/property-invitations.service';
 
 describe('PropertyInvitationsController', () => {
   let controller: PropertyInvitationsController;
+  let mockPropertyInvitationsService: jest.Mocked<PropertyInvitationsService>;
 
   beforeEach(async () => {
-    const {unit} = TestBed.create(PropertyInvitationsController).compile();
+    const {unit, unitRef} = TestBed.create(
+      PropertyInvitationsController,
+    ).compile();
     controller = unit;
+
+    mockPropertyInvitationsService = unitRef.get<PropertyInvitationsService>(
+      PropertyInvitationsService,
+    );
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+    expect(mockPropertyInvitationsService).toBeDefined();
+  });
+
+  it('should create a property invitation', async () => {
+    const currentUserEmail = faker.internet.email();
+    const currentUserName = faker.internet.displayName();
+    const id = faker.string.uuid();
+    const email = faker.internet.email();
+
+    mockPropertyInvitationsService.inviteTenantToProperty.mockResolvedValue({
+      status: 'success',
+    } as never);
+
+    const result = await controller.createPropertyInvitation(
+      {
+        email: currentUserEmail,
+        user_metadata: {name: currentUserName},
+      } as unknown as AuthUser,
+      {id},
+      {email},
+    );
+
+    expect(
+      mockPropertyInvitationsService.inviteTenantToProperty,
+    ).toHaveBeenCalledWith(
+      currentUserEmail.toLowerCase(),
+      currentUserName,
+      id,
+      email.toLowerCase(),
+    );
+    expect(result).toStrictEqual({status: 'success'});
+  });
+
+  it('should accept a property invitation', async () => {
+    const currentUserEmail = faker.internet.email();
+    const id = faker.string.uuid();
+    const tokenValue = faker.string.uuid();
+
+    mockPropertyInvitationsService.acceptInvitationToProperty.mockResolvedValue(
+      {status: 'success'} as never,
+    );
+
+    const result = await controller.acceptInvitation(
+      {email: currentUserEmail} as AuthUser,
+      {id},
+      {tokenValue},
+    );
+
+    expect(
+      mockPropertyInvitationsService.acceptInvitationToProperty,
+    ).toHaveBeenCalledWith(currentUserEmail.toLowerCase(), id, tokenValue);
+    expect(result).toStrictEqual({status: 'success'});
   });
 });

--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/_children/property-invitations/controllers/property-invitations.controller.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/_children/property-invitations/controllers/property-invitations.controller.ts
@@ -15,7 +15,7 @@ export class PropertyInvitationsController {
   ) {}
 
   @Post('to-property/:id')
-  create(
+  createPropertyInvitation(
     @CurrentUser()
     currentUser: AuthUser,
     @Param() {id}: IdParamDto,
@@ -33,7 +33,7 @@ export class PropertyInvitationsController {
   acceptInvitation(
     @CurrentUser() currentUser: AuthUser,
     @Param() {id}: IdParamDto,
-    @Body() {tokenValue}: any,
+    @Body() {tokenValue}: {tokenValue: string},
   ) {
     return this.propertyInvitationsService.acceptInvitationToProperty(
       currentUser.email?.toLowerCase(),

--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/controllers/properties.controller.spec.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/controllers/properties.controller.spec.ts
@@ -34,7 +34,7 @@ describe('PropertiesController', () => {
       createPropertyDto,
     );
 
-    expect(mockPropertiesService.create).toHaveBeenCalledWith(
+    expect(mockPropertiesService.createProperty).toHaveBeenCalledWith(
       requestingUserEmail.toLowerCase(),
       createPropertyDto,
     );

--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/controllers/properties.controller.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/controllers/properties.controller.ts
@@ -34,7 +34,7 @@ export class PropertiesController {
     this.logger.log(
       `Request from: ${currentUser.email} to create property with name: ${createPropertyDto.name}`,
     );
-    return this.propertiesService.create(
+    return this.propertiesService.createProperty(
       currentUser.email?.toLowerCase(),
       createPropertyDto,
     );

--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/services/properties.service.it.spec.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/services/properties.service.it.spec.ts
@@ -75,7 +75,7 @@ describe('PropertiesService Integration Tests', () => {
       name: faker.internet.displayName(),
     };
 
-    const result = await service.create(requestingUserEmail, property);
+    const result = await service.createProperty(requestingUserEmail, property);
 
     const returnedProperty = await service.getPropertyForViewing(
       requestingUserEmail,

--- a/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/services/properties.service.ts
+++ b/web/backend/rl-nestjs-mono/src/app/ledgers/_children/properties/services/properties.service.ts
@@ -20,7 +20,7 @@ export class PropertiesService {
     private readonly paymentsService: PaymentsService,
   ) {}
 
-  async create(
+  async createProperty(
     requestingUserEmail: string,
     createPropertyDto: CreatePropertyDto,
   ) {

--- a/web/backend/rl-nestjs-mono/src/app/payments/controllers/payments.controller.spec.ts
+++ b/web/backend/rl-nestjs-mono/src/app/payments/controllers/payments.controller.spec.ts
@@ -1,7 +1,10 @@
 import {TestBed} from '@automock/jest';
+import {faker} from '@faker-js/faker';
+import {AuthUser} from '@supabase/supabase-js';
 
 import {PaymentsController} from './payments.controller';
 import {PaymentsService} from '../services/payments.service';
+import {PaymentStatus} from '../types/PaymentStatus.type';
 
 describe('PaymentsController', () => {
   let controller: PaymentsController;
@@ -17,5 +20,26 @@ describe('PaymentsController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
     expect(mockPaymentsService).toBeDefined();
+  });
+
+  it('should return customer payment status', async () => {
+    const customerEmail = faker.internet.email();
+    const currentUser = {email: customerEmail};
+    const paymentStatus: PaymentStatus = 'PAID';
+
+    mockPaymentsService.getCustomerPaymentStatus.mockResolvedValue({
+      status: paymentStatus,
+    });
+
+    const result = await controller.getCustomerPaymentStatus(
+      currentUser as AuthUser,
+    );
+
+    expect(result).toStrictEqual({
+      status: paymentStatus,
+    });
+    expect(mockPaymentsService.getCustomerPaymentStatus).toHaveBeenCalledWith(
+      customerEmail.toLowerCase(),
+    );
   });
 });


### PR DESCRIPTION
* Refactor property creation method and add payment status test

Renamed the `create` method to `createProperty` in the properties service and updated all references to ensure consistency. Additionally, introduced a new test for the `PaymentsController` to verify customer payment status retrieval.

* Refactor controller method names and improve tests

Renamed methods in PropertyInvitationsController for clarity and updated the body type in acceptInvitation. Enhanced test coverage by adding unit tests for createPropertyInvitation and acceptInvitation methods, leveraging Faker for mock data.