### PR TITLE
Switch to `provideAppInitializer` for app initialization

### DIFF
--- a/web/frontend/rl-angular-spa/src/app/default-app-providers.ts
+++ b/web/frontend/rl-angular-spa/src/app/default-app-providers.ts
@@ -1,6 +1,6 @@
 import {DOCUMENT} from '@angular/common';
 import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/http';
-import {APP_INITIALIZER} from '@angular/core';
+import {provideAppInitializer} from '@angular/core';
 import {MAT_SNACK_BAR_DEFAULT_OPTIONS} from '@angular/material/snack-bar';
 import {provideMomentDateAdapter} from '@angular/material-moment-adapter';
 import {provideAnimations} from '@angular/platform-browser/animations';
@@ -27,11 +27,9 @@ const MY_FORMATS = {
 };
 
 export const DEFAULT_APP_PROVIDERS = [
-  {
-    provide: APP_INITIALIZER,
-    useFactory: initializeApp,
-    multi: true,
-  },
+  provideAppInitializer(() => {
+    initializeApp();
+  }),
   provideRouter(routes),
   provideHttpClient(
       withFetch(),


### PR DESCRIPTION
Replaced the use of `APP_INITIALIZER` with `provideAppInitializer` to improve clarity and maintain consistency with the latest Angular practices. This change ensures the application initialization logic is more concise and streamlined.